### PR TITLE
Add stingray launcher

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ out/
 npm-debug.log
 stingray-debug.txt
 *.vsix
+*.dmp

--- a/package.json
+++ b/package.json
@@ -1,195 +1,204 @@
 {
-    "name": "stingray-debug",
-    "displayName": "Stingray Debugger",
-    "version": "0.10.14",
-    "description": "Extension to debug Autodesk Stingray application and games.",
-    "author": {
-        "url": "https://github.com/jschmidt42",
-        "name": "Jonathan Schmidt",
-        "email": "jschmidt42@gmail.com"
-    },
-    "keywords": [
-        "autodesk",
-        "stingray",
-        "debugger",
-        "lua"
-    ],
-    "publisher": "jschmidt42",
-    "engines": {
-        "vscode": "^1.1.0",
-        "node": "^6.5.0"
-    },
-    "icon": "images/icon.png",
-    "categories": [
-        "Debuggers",
-        "Languages"
-    ],
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/jschmidt42/stingray-vscode-debugger.git"
-    },
-    "dependencies": {
-        "ws": "^2.2.2",
-        "lodash": "^4.17.4",
-        "vscode-debugadapter": "^1.18.0-pre.4",
-        "vscode-debugprotocol": "^1.18.0-pre.2"
-    },
-    "devDependencies": {
-        "@types/es6-collections": "^0.5.29",
-        "@types/es6-promise": "^0.0.32",
-        "@types/mocha": "^2.2.33",
-        "@types/node": "^6.0.50",
-        "typescript": "^2.0.10",
-        "mocha": "^3.1.2",
-        "vscode": "^1.1.0",
-        "vscode-debugadapter-testsupport": "^1.17.0"
-    },
-    "scripts": {
-        "prepublish": "node ./node_modules/typescript/bin/tsc -p ./src",
-        "compile": "node ./node_modules/typescript/bin/tsc -p ./src",
-        "watch": "node ./node_modules/typescript/bin/tsc -w -p ./src",
-        "postinstall": "node ./node_modules/vscode/bin/install"
-    },
-    "main": "./out/extension",
-    "activationEvents": [
-        "onCommand:extension.stingray-debug.getProgramName",
-        "onCommand:extension.stingray-debug.provideInitialConfigurations"
-    ],
-    "contributes": {
-        "languages": [{
-            "id": "sjson",
-            "aliases": ["sjson", "sjson"],
-            "extensions": [
-                ".sjson",
-                ".material",
-                ".shader",
-                ".shader_node",
-                ".shader_source",
-                ".render_config",
-                ".particles",
-                ".bsi",
-                ".texture",
-                ".unit",
-                ".physics",
-                ".landscape",
-                ".level",
-                ".timpani_bank",
-                ".timpani_master",
-                ".mouse_cursor",
-                ".surface_properties",
-                ".physics_properties",
-                ".decals",
-                ".script_flow_nodes",
-                ".flow",
-                ".network_config",
-                ".strings",
-                ".volume_type",
-                ".package",
-                ".entity",
-                ".sound_environment",
-                ".texture_category",
-                ".stingray_project",
-                ".stingray_plugin",
-                ".plugin",
-                ".shading_environment_template",
-                ".shading_environment"],
-            "configuration": "./language-configuration.json"
-        }],
-        "grammars": [{
-            "language": "sjson",
-            "scopeName": "source.sjson",
-            "path": "./syntaxes/SJSON.tmLanguage"
-        }],
-        "breakpoints": [
-            {
-                "language": "lua"
-            }
+  "name": "stingray-debug",
+  "displayName": "Stingray Debugger",
+  "version": "0.10.14",
+  "description": "Extension to debug Autodesk Stingray application and games.",
+  "author": {
+    "url": "https://github.com/jschmidt42",
+    "name": "Jonathan Schmidt",
+    "email": "jschmidt42@gmail.com"
+  },
+  "keywords": [
+    "autodesk",
+    "stingray",
+    "debugger",
+    "lua"
+  ],
+  "publisher": "jschmidt42",
+  "engines": {
+    "vscode": "^1.1.0",
+    "node": "^6.5.0"
+  },
+  "icon": "images/icon.png",
+  "categories": [
+    "Debuggers",
+    "Languages"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jschmidt42/stingray-vscode-debugger.git"
+  },
+  "dependencies": {
+    "lodash": "^4.17.4",
+    "simplified-json": "^0.2.0",
+    "vscode-debugadapter": "^1.18.0-pre.4",
+    "vscode-debugprotocol": "^1.18.0-pre.2",
+    "ws": "^2.2.2"
+  },
+  "devDependencies": {
+    "@types/es6-collections": "^0.5.29",
+    "@types/es6-promise": "^0.0.32",
+    "@types/mocha": "^2.2.33",
+    "@types/node": "^6.0.50",
+    "typescript": "^2.0.10",
+    "mocha": "^3.1.2",
+    "vscode": "^1.1.0",
+    "vscode-debugadapter-testsupport": "^1.17.0"
+  },
+  "scripts": {
+    "prepublish": "node ./node_modules/typescript/bin/tsc -p ./src",
+    "compile": "node ./node_modules/typescript/bin/tsc -p ./src",
+    "watch": "node ./node_modules/typescript/bin/tsc -w -p ./src",
+    "postinstall": "node ./node_modules/vscode/bin/install"
+  },
+  "main": "./out/extension",
+  "activationEvents": [
+    "onCommand:extension.stingray-debug.getProgramName",
+    "onCommand:extension.stingray-debug.provideInitialConfigurations"
+  ],
+  "contributes": {
+    "languages": [
+      {
+        "id": "sjson",
+        "aliases": [
+          "sjson",
+          "sjson"
         ],
-        "debuggers": [
-            {
-                "type": "stingray",
-                "label": "Stingray",
-                "program": "./out/stingray-debugger.js",
-                "runtime": "node",
-                "variables": {
-                    "AskForProgramName": "extension.stingray-debug.getProgramName"
-                },
-                "configurationSnippets": [
-                    {
-                        "label": "Stingray: Application (lua)",
-                        "description": "A new configuration for debugging a Stingray application.",
-                        "body": {
-                            "type": "stingray",
-                            "request": "launch",
-                            "name": "${1:My application name}",
-                            "toolchain": "C:/path/to/stingray/binaries/installation",
-                            "project_file": "^\"\\${workspaceRoot}/project.stingray_project\""
-                        }
-                    },
-                    {
-                        "label": "Stingray: Editor Engine (14030)",
-                        "description": "A new configuration for debugging a Stingray Editor Engine instance",
-                        "body": {
-                            "type": "stingray",
-                            "request": "attach",
-                            "name": "${2:Stingray Editor}",
-                            "ip": "127.0.0.1",
-                            "port": 14030
-                        }
-                    },
-                    {
-                        "label": "Stingray: Asset Server (14032)",
-                        "description": "A new configuration for debugging the Stingray Asset Server console",
-                        "body": {
-                            "type": "stingray",
-                            "request": "attach",
-                            "name": "${2:Stingray Asset Server}",
-                            "ip": "127.0.0.1",
-                            "port": 14032
-                        }
-                    }
-                ],
-                "configurationAttributes": {
-                    "launch": {
-                        "required": [
-                            "toolchain"
-                        ],
-                        "properties": {
-                            "toolchain": {
-                                "type": "string",
-                                "description": "Stingray binaries installation folder."
-                            },
-                            "project_file": {
-                                "type": "string",
-                                "description": "Stingray project settings file path (i.e. *.stingray_project)"
-                            },
-                            "command_line_args": {
-                                "type": "array",
-                                "description": "Additional command line arguments passed to the engine."
-                            }
-                        }
-                    },
-
-                    "attach": {
-                        "required": [
-                            "ip", "port"
-                        ],
-                        "properties": {
-                            "ip": {
-                                "type": "string",
-                                "description": "Stingray Application console IP",
-                                "default": "127.0.0.1"
-                            },
-                            "port": {
-                                "type": "number",
-                                "description": "Stingray Application console port (see settings.ini)",
-                                "default": 14031
-                            }
-                        }
-                    }
-                },
-                "initialConfigurations": "extension.stingray-debug.provideInitialConfigurations"
+        "extensions": [
+          ".sjson",
+          ".material",
+          ".shader",
+          ".shader_node",
+          ".shader_source",
+          ".render_config",
+          ".particles",
+          ".bsi",
+          ".texture",
+          ".unit",
+          ".physics",
+          ".landscape",
+          ".level",
+          ".timpani_bank",
+          ".timpani_master",
+          ".mouse_cursor",
+          ".surface_properties",
+          ".physics_properties",
+          ".decals",
+          ".script_flow_nodes",
+          ".flow",
+          ".network_config",
+          ".strings",
+          ".volume_type",
+          ".package",
+          ".entity",
+          ".sound_environment",
+          ".texture_category",
+          ".stingray_project",
+          ".stingray_plugin",
+          ".plugin",
+          ".shading_environment_template",
+          ".shading_environment"
+        ],
+        "configuration": "./language-configuration.json"
+      }
+    ],
+    "grammars": [
+      {
+        "language": "sjson",
+        "scopeName": "source.sjson",
+        "path": "./syntaxes/SJSON.tmLanguage"
+      }
+    ],
+    "breakpoints": [
+      {
+        "language": "lua"
+      }
+    ],
+    "debuggers": [
+      {
+        "type": "stingray",
+        "label": "Stingray",
+        "program": "./out/stingray-debugger.js",
+        "runtime": "node",
+        "variables": {
+          "AskForProgramName": "extension.stingray-debug.getProgramName"
+        },
+        "configurationSnippets": [
+          {
+            "label": "Stingray: Application (lua)",
+            "description": "A new configuration for debugging a Stingray application.",
+            "body": {
+              "type": "stingray",
+              "request": "launch",
+              "name": "${1:My application name}",
+              "toolchain": "C:/path/to/stingray/binaries/installation",
+              "project_file": "^\"\\${workspaceRoot}/project.stingray_project\""
             }
-        ]
-    }
+          },
+          {
+            "label": "Stingray: Editor Engine (14030)",
+            "description": "A new configuration for debugging a Stingray Editor Engine instance",
+            "body": {
+              "type": "stingray",
+              "request": "attach",
+              "name": "${2:Stingray Editor}",
+              "ip": "127.0.0.1",
+              "port": 14030
+            }
+          },
+          {
+            "label": "Stingray: Asset Server (14032)",
+            "description": "A new configuration for debugging the Stingray Asset Server console",
+            "body": {
+              "type": "stingray",
+              "request": "attach",
+              "name": "${2:Stingray Asset Server}",
+              "ip": "127.0.0.1",
+              "port": 14032
+            }
+          }
+        ],
+        "configurationAttributes": {
+          "launch": {
+            "required": [
+              "toolchain"
+            ],
+            "properties": {
+              "toolchain": {
+                "type": "string",
+                "description": "Stingray binaries installation folder."
+              },
+              "project_file": {
+                "type": "string",
+                "description": "Stingray project settings file path (i.e. *.stingray_project)"
+              },
+              "command_line_args": {
+                "type": "array",
+                "description": "Additional command line arguments passed to the engine."
+              }
+            }
+          },
+          "attach": {
+            "required": [
+              "ip",
+              "port"
+            ],
+            "properties": {
+              "ip": {
+                "type": "string",
+                "description": "Stingray Application console IP",
+                "default": "127.0.0.1"
+              },
+              "port": {
+                "type": "number",
+                "description": "Stingray Application console port (see settings.ini)",
+                "default": 14031
+              }
+            }
+          }
+        },
+        "initialConfigurations": "extension.stingray-debug.provideInitialConfigurations"
+      }
+    ]
+  }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,10 +11,10 @@ const initialConfigurations = {
 	configurations: [
 		{
 			type: 'stingray',
-			request: 'launch',
+			request: 'attach',
 			name: 'Stingray Debug',
 			ip: "127.0.0.1",
-			port: 14030
+			port: 14000
 		}
 	]
 };

--- a/src/stingray-debugger.ts
+++ b/src/stingray-debugger.ts
@@ -101,6 +101,9 @@ class StingrayDebugSession extends DebugSession {
     // Indicates the if the debug adapter is still initializing.
     private _initializing: boolean = false;
 
+    // Deferred response to indicate we are now successfully attached.
+    private _attachResponse: DebugProtocol.Response;
+
     /**
      * Creates a new debug adapter that is used for one debug session.
      * We configure the default implementation of a debug adapter here.
@@ -123,6 +126,11 @@ class StingrayDebugSession extends DebugSession {
         response.body.supportsEvaluateForHovers = true;
         response.body.supportsConfigurationDoneRequest = true;
 
+        this.sendEvent(new InitializedEvent());
+        this.sendResponse(response);
+    }
+
+    protected configurationDoneRequest(response: DebugProtocol.ConfigurationDoneResponse, args: DebugProtocol.ConfigurationDoneArguments): void {
         this.sendResponse(response);
     }
 
@@ -425,6 +433,7 @@ class StingrayDebugSession extends DebugSession {
 
         // Request engine status
         this._initializing = true;
+        this._attachResponse = response;
         this._conn.sendDebuggerCommand('report_status');
     }
 
@@ -444,7 +453,7 @@ class StingrayDebugSession extends DebugSession {
 
         if (this._initializing) {
             // Since we now know the state of the engine, lets proceed with the client initialization.
-            this.sendEvent(new InitializedEvent());
+            this.sendResponse(this._attachResponse);
             this._initializing = false;
         }
 

--- a/src/stingray-launcher.ts
+++ b/src/stingray-launcher.ts
@@ -1,0 +1,85 @@
+
+import _ = require('lodash');
+import * as path from 'path';
+import * as fs from 'fs';
+import {readFileSync as readFile, existsSync as fileExists} from 'fs';
+import child_process = require('child_process');
+import SJSON = require('simplified-json');
+
+var exec = child_process.exec;
+
+export const DEFAULT_ENGINE_CONSOLE_PORT = 14000;
+
+export class StingrayEngineProcess {
+    public ip: string;
+    public port: number;
+    public cmdline: string;
+
+    public exePath: string;
+
+    constructor (exePath: string) {
+        this.ip = '127.0.0.1';
+        this.port = DEFAULT_ENGINE_CONSOLE_PORT;
+        this.exePath = exePath;
+        if (!fileExists(this.exePath))
+            throw new Error(`Invalid engine executable path ${this.exePath}`);
+    }
+
+    start (args:Array<string|number> = [], port: number = DEFAULT_ENGINE_CONSOLE_PORT) {
+        args = args.concat([
+            "--port", port
+        ]);
+        this.port = port;
+        this.cmdline = `"${this.exePath}" ${args.join(' ')}`;
+        exec(this.cmdline, (error, stdout, stderr) => {
+            // result
+        });
+    }
+}
+
+export class StingrayLauncher {
+    private dataDir: string;
+    private srpPath: any;
+    private tcPath: string;
+
+    constructor (tcPath: string, srpPath: string) {
+
+        if (!fileExists(tcPath))
+            throw new Error(`Invalid ${tcPath} toolchain folder path`);
+
+        if (!fileExists(srpPath))
+            throw new Error(`Invalid ${srpPath} project path`);
+
+        this.tcPath = tcPath;
+        this.srpPath = srpPath;
+
+        // Read project settings to get data dir
+        let srpSJSON = readFile(this.srpPath, 'utf8');
+        let srp = SJSON.parse(srpSJSON);
+
+        // Get project data dir.
+        let srpDir = path.dirname(srpPath);
+        let srpDirName = path.basename(srpDir);
+        if (srp.data_directory) {
+            if (fileExists(srp.data_directory))
+                this.dataDir = path.resolve(srp.data_directory);
+            else
+                this.dataDir = path.join(srpDir, srp.data_directory);
+        } else
+            this.dataDir = path.join(srpDir, "..", srpDirName + "_data");
+
+        // Add platform to data dir, default to `win32` for now.
+        this.dataDir = path.join(this.dataDir, 'win32');
+    }
+
+    public start (): StingrayEngineProcess {
+        let engineExe = path.join(this.tcPath, 'engine', 'win64', 'dev', 'stingray_win64_dev.exe');
+        let engineProcess = new StingrayEngineProcess(engineExe);
+        engineProcess.start([
+            "--data-dir", `"${this.dataDir}"`,
+            //"--wait-for-debugger"
+        ], DEFAULT_ENGINE_CONSOLE_PORT);
+
+        return engineProcess;
+    }
+}


### PR DESCRIPTION
Add a Stingray launcher module to execute the engine in the context of the selected project and then attach the debugger to that running instance.

@lochrist please review