### PR TITLE
Add support for --wait-for-debugger

### DIFF
--- a/src/stingray-launcher.ts
+++ b/src/stingray-launcher.ts
@@ -77,7 +77,7 @@ export class StingrayLauncher {
         let engineProcess = new StingrayEngineProcess(engineExe);
         engineProcess.start([
             "--data-dir", `"${this.dataDir}"`,
-            //"--wait-for-debugger"
+            "--wait-for-debugger"
         ], DEFAULT_ENGINE_CONSOLE_PORT);
 
         return engineProcess;


### PR DESCRIPTION
Spawn the engine with `--wait-for-debugger` and once all breakpoints have been loaded, respond back to the engine to the `waiting` message by sending a `continue` debug command.

@lochrist FYI