### PR TITLE
Add engine exe configuration

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -2,7 +2,7 @@
 	"version": "0.1.0",
 	"command": "npm",
 	"isShellCommand": true,
-	"isBackground": true,
+	"isWatching": true,
 	"showOutput": "always",
 	"args": [
 		"run", "watch"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.0
+* Rename to Autodesk Interactive
+* Read Stingray TCC app.config to get extra settings.
+* Allow the user to configure what is the EXE engine name to be launched.
+
 ## 1.5
 * Add plugin resource extensions support.
 * Add additional command line arguments support.

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
     "name": "stingray-debug",
-    "displayName": "Stingray Debugger",
-    "version": "1.5.0",
-    "description": "Extension to debug Autodesk Stingray applications and games.",
+    "displayName": "Autodesk Interactive Debugger",
+    "version": "2.0.0",
+    "description": "Extension to debug Autodesk Interactive applications and games.",
     "license": "MIT",
     "author": {
         "url": "https://github.com/jschmidt42",
@@ -11,13 +11,14 @@
     },
     "keywords": [
         "autodesk",
+        "interactive",
         "stingray",
         "debugger",
         "lua"
     ],
     "publisher": "jschmidt42",
     "engines": {
-        "vscode": "^1.1.0",
+        "vscode": "^1.1.5",
         "node": "^6.5.0"
     },
     "icon": "images/icon.png",
@@ -32,8 +33,8 @@
     "dependencies": {
         "lodash": "^4.17.4",
         "simplified-json": "^0.2.0",
-        "vscode-debugadapter": "^1.18.0-pre.4",
-        "vscode-debugprotocol": "^1.18.0-pre.2",
+        "vscode-debugprotocol": "^1.19.0",
+        "vscode-debugadapter": "^1.19.0",
         "ws": "^2.2.2"
     },
     "devDependencies": {
@@ -42,13 +43,15 @@
         "@types/mocha": "^2.2.33",
         "@types/node": "^6.0.50",
         "mocha": "^3.1.2",
-        "typescript": "^2.3.4",
-        "vscode": "^1.1.0",
-        "vscode-debugadapter-testsupport": "^1.17.0"
+        "tslint": "^5.7.0",
+        "typescript": "^2.5.1",
+        "vscode": "^1.1.5",
+        "vscode-debugadapter-testsupport": "^1.19.0"
     },
     "scripts": {
         "prepublish": "node ./node_modules/typescript/bin/tsc -p ./src",
         "compile": "node ./node_modules/typescript/bin/tsc -p ./src",
+        "tslint": "tslint ./src/**/*.ts",
         "watch": "node ./node_modules/typescript/bin/tsc -w -p ./src",
         "postinstall": "node ./node_modules/vscode/bin/install"
     },
@@ -93,6 +96,7 @@
                 ],
                 "extensions": [
                     ".sjson",
+                    ".config",
                     ".material",
                     ".shader",
                     ".shader_node",
@@ -169,6 +173,7 @@
                             "request": "launch",
                             "name": "${1:My application name}",
                             "toolchain": "C:/path/to/stingray/binaries/installation",
+                            "engine_exe": "interactive_win64_dev.exe",
                             "project_file": "^\"\\${workspaceRoot}/project.stingray_project\"",
                             "compile": true,
                             "additional_plugins": []
@@ -207,6 +212,10 @@
                             "toolchain": {
                                 "type": "string",
                                 "description": "Stingray installation folder. e.g. C:/Program Files/Autodesk/Stingray/1.8.1267.0"
+                            },
+                            "engine_exe": {
+                                "type": "string",
+                                "description": "Stingray executable name. e.g. stingray_win64_dev.exe"
                             },
                             "project_file": {
                                 "type": "string",

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
-# Stingray Debugger
+# Autodesk Interactive Debugger
 
-Use the [Visual Studio Code](https://code.visualstudio.com) editor and debugger with your [Autodesk® Stingray](http://www.stingrayengine.com) projects!
+Use the [Visual Studio Code](https://code.visualstudio.com) editor and debugger with your [Autodesk® Interactive](https://forge.autodesk.com/categories/arvr) projects!
 
 Find the extension [here, in the Visual Studio Code marketplace](https://marketplace.visualstudio.com/items?itemName=jschmidt42.stingray-debug).
 
@@ -11,19 +11,19 @@ Find the extension [here, in the Visual Studio Code marketplace](https://marketp
 
 ## Description
 
-This extension makes Visual Studio Code into a full-featured code editing debugging environment for your Stingray projects. You can connect the debugger to a running engine, launch a project, trigger breakpoints and step through your project's Lua code, view variable values, send commands to the engine, and more.
+This extension makes Visual Studio Code into a full-featured code editing debugging environment for your Autodesk Interactive projects. You can connect the debugger to a running engine, launch a project, trigger breakpoints and step through your project's Lua code, view variable values, send commands to the engine, and more.
 
-If you haven't heard about Stingray yet, check out the following links:
+If you haven't heard about Autodesk Interactive yet, check out the following links:
 
-- [The main Stingray site at www.autodesk.com](https://www.autodesk.com/products/stingray/overview), where you can download a trial version.
-- [The Stingray Learning Center](http://help.autodesk.com/view/Stingray/ENU/), where you can find help, tutorials, and reference docs.
-- [The Stingray SDK Help](http://help.autodesk.com/view/Stingray/ENU/?guid=__sdk_help_introduction_html), useful if you want to write your own plug-in to extend Stingray.
+- [The main Autodesk Interactive site at www.autodesk.com](https://www.autodesk.com/products/stingray/overview), where you can download a trial version.
+- [The Autodesk Interactive Learning Center](http://help.autodesk.com/view/Stingray/ENU/), where you can find help, tutorials, and reference docs.
+- [The Autodesk Interactive SDK Help](http://help.autodesk.com/view/Stingray/ENU/?guid=__sdk_help_introduction_html), useful if you want to write your own plug-in to extend Autodesk Interactive.
 
 ## Step 1. Install the extension
 
 Bring up the Extensions view by clicking the Extensions icon in the Activity Bar on the left side of Visual Studio Code, or selecting **View > Extensions** (`Ctrl+Shift+X`) from the main menu.
 
-Search for `Stingray Debugger`. You should find something like this:
+Search for `Autodesk Interactive Debugger`. You should find something like this:
 
 ![image](https://cloud.githubusercontent.com/assets/4054655/24268552/7b89627a-0fe4-11e7-83e8-f170e0aebfd9.png)
 
@@ -31,7 +31,7 @@ For more about installing extensions, see the [Visual Studio Code user guide](ht
 
 ## Step 2. Open your project folder
 
-Open your Stingray project folder in Visual Studio Code. This will be your workspace, where Visual Studio Code will keep your debug configurations.
+Open your Autodesk Interactive project folder in Visual Studio Code. This will be your workspace, where Visual Studio Code will keep your debug configurations.
 
 Select **File > Open Folder** (`Ctrl+K Ctrl+O`) from the main menu, and browse to the folder that contains your project's *.stingray_project* file.
 
@@ -43,7 +43,7 @@ A *debug configuration* tells the Visual Studio Code debugger what it should do 
 
 You can read some background about these configs [here](https://code.visualstudio.com/docs/editor/debugging).
 
-You'll have to create at least one new debug configuration in order to make the debugger able to attach to or launch the Stingray engine.
+You'll have to create at least one new debug configuration in order to make the debugger able to attach to or launch the Autodesk Interactive engine.
 
 1.	Bring up the Debug view by clicking the Debug icon in the Activity Bar on the left side of Visual Studio Code, or by selecting **View > Debug** (`Ctrl+Shift+D`) from the main menu.
 
@@ -57,7 +57,7 @@ You'll have to create at least one new debug configuration in order to make the 
 
 ### Attach to a running engine
 
-You can make the Visual Studio Code debugger connect to a running instance of the Stingray engine. Use the following launch configuration:
+You can make the Visual Studio Code debugger connect to a running instance of the Autodesk Interactive engine. Use the following launch configuration:
 
 ```javascript
 {
@@ -66,7 +66,7 @@ You can make the Visual Studio Code debugger connect to a running instance of th
 	"request": "attach", // Use attach here to make the debugger connect to an existing process.
 	"name": "My Stingray Game",
 
-	// The IP address of the device running the Stingray engine.
+	// The IP address of the device running the Autodesk Interactive engine.
 	"ip": "127.0.0.1",
 
 	// The port the engine is using for console communications.
@@ -80,7 +80,7 @@ The `port` setting to use depends on how you've launched the engine:
 
 -	If you launched the engine on Windows using the editor's Run Project feature, or by running a deployed project (with the `dev` configuration), the engine chooses a free port between `14000` and `14030` inclusive. This means that you might not have the same port number every time you run. To specify a pre-set port number when you launch the engine, you can use the `--port <number>` command-line parameter.
 
-	**Tip:** to specify a port when you use the editor's Run Project feature, add the `--port <number>` command-line parameter to the default `localhost` connection listed in the **Connections** panel of the Stingray editor.
+	**Tip:** to specify a port when you use the editor's Run Project feature, add the `--port <number>` command-line parameter to the default `localhost` connection listed in the **Connections** panel of the Autodesk Interactive editor.
 
 -	You can also connect to the instance engine that the editor runs internally. This can be useful in order to debug the Lua code in the `core/editor_slave` folder, which provides viewport behaviors for the editor. In this case, use port `14030`.
 
@@ -88,7 +88,7 @@ The `port` setting to use depends on how you've launched the engine:
 
 ### Launch a project and attach
 
-You can make the Visual Studio Code debugger launch the Stingray engine with a specific project, and immediately attach itself to that instance of the engine. The engine will wait for the debugger to connect and start the debugging session before it runs any Lua initialization code.
+You can make the Visual Studio Code debugger launch the Autodesk Interactive engine with a specific project, and immediately attach itself to that instance of the engine. The engine will wait for the debugger to connect and start the debugging session before it runs any Lua initialization code.
 
 Launching the game from the debugger like this makes it easy to trigger breakpoints in your initialization code:
 
@@ -105,6 +105,9 @@ To set this up, use a launch configuration like this:
 
 	// Folder where Stingray is installed.
 	"toolchain": "C:\\Program Files\\Autodesk\\Stingray\\1.8.1218.0",
+
+    // Stingray executable name
+    "engine_exe": "interactive_win64_dev.exe";
 
 	// Full path to the project you want to launch for debugging.
 	"project_file": "D:/pitchcrawl/pitchcrawl.stingray_project",
@@ -128,7 +131,7 @@ To set this up, use a launch configuration like this:
 }
 ```
 
-You don't have to provide any command-line parameters. The debugger extension will set the ones it needs, like `--port` and `--data-dir`. But you can add your own if you want to customize something about the way the engine starts up. For the complete list of command-line arguments the engine accepts, see [the Stingray Help](http://help.autodesk.com/view/Stingray/ENU/?guid=__stingray_help_reference_engine_command_line_html).
+You don't have to provide any command-line parameters. The debugger extension will set the ones it needs, like `--port` and `--data-dir`. But you can add your own if you want to customize something about the way the engine starts up. For the complete list of command-line arguments the engine accepts, see [the Autodesk Interactive Help](http://help.autodesk.com/view/Stingray/ENU/?guid=__stingray_help_reference_engine_command_line_html).
 
 ## Step 5. Start debugging!
 
@@ -164,7 +167,7 @@ Whenever the engine evaluates a line of code that has a breakpoint set, it pause
 
 ### Read console messages
 
-Just like the **Log Console** in the Stingray editor, the **Debug Console** in Visual Studio Code prints out all console messages sent by the connected engine:
+Just like the **Log Console** in the Autodesk Interactive editor, the **Debug Console** in Visual Studio Code prints out all console messages sent by the connected engine:
 
 ![engine message output](https://cloud.githubusercontent.com/assets/4054655/24308807/da2a0008-109f-11e7-970b-5d82953c0fe0.gif)
 
@@ -178,7 +181,7 @@ You can send console commands to the engine from the **Debug Console**. Prefix t
 
 You can also send commands from the **Command Palette**. Open the Command Palette, type `Stingray Command` and hit `Enter`. Then, enter the command you want to send (without the `--` prefix).
 
-For a list of all available console commands and their parameters, see [the Stingray help](http://help.autodesk.com/view/Stingray/ENU/?guid=__stingray_help_reference_console_commands_html).
+For a list of all available console commands and their parameters, see [the Autodesk Interactive help](http://help.autodesk.com/view/Stingray/ENU/?guid=__stingray_help_reference_console_commands_html).
 
 ### Send engine scripts
 
@@ -188,15 +191,15 @@ Everything that you type in the **Debug Console** that is *not* prefixed with `-
 
 ## Code editing features
 
-This extension does more than just debugging: it also adds some extra features to the code editor that you'll find especially handy when you work with Stingray projects.
+This extension does more than just debugging: it also adds some extra features to the code editor that you'll find especially handy when you work with Autodesk Interactive projects.
 
-### Stingray Lua API hovering support
+### Autodesk Interactive Lua API hovering support
 
-Hover over any function from the Stingray API to get the function's signature and brief description:
+Hover over any function from the Autodesk Interactive API to get the function's signature and brief description:
 
 ![hovering](images/hovering.png)
 
-### Stingray Lua API function signatures
+### Autodesk Interactive Lua API function signatures
 
 You'll also be reminded of the signature and description as you type the opening bracket for a function:
 
@@ -204,7 +207,7 @@ You'll also be reminded of the signature and description as you type the opening
 
 ### Syntax highlighting for SJSON resources
 
-The code editor shows appropriate syntax highlighting for Stingray resource types that use [SJSON format](http://help.autodesk.com/view/Stingray/ENU/?guid=__stingray_help_managing_content_sjson_html), like *.unit*, *.level*, and *.script_flow_nodes*.
+The code editor shows appropriate syntax highlighting for Autodesk Interactive resource types that use [SJSON format](http://help.autodesk.com/view/Stingray/ENU/?guid=__stingray_help_managing_content_sjson_html), like *.unit*, *.level*, and *.script_flow_nodes*.
 
 ![SJSON highlighting](images/sjson.png)
 

--- a/src/launcher.ts
+++ b/src/launcher.ts
@@ -9,6 +9,7 @@ import {findResourceMaps} from './plugins';
 
 export interface LaunchConfiguration {
     tcPath: string;
+    engineExe: string;
     projectPath: string;
     additionalPlugins?: string[];
     commandLineArgs?: string[];
@@ -22,10 +23,14 @@ export class EngineLauncher {
     private coreRootDir: string;
     private srpPath: any;
     private tcPath: string;
+    private engineExe: string;
 
     constructor (config: LaunchConfiguration) {
         const tcPath = config.tcPath;
+        const engineExe = config.engineExe || "interactive_win64_dev.exe";
         const srpPath = config.projectPath;
+
+        // TODO: Validate that engine exe exists.
 
         if (!fileExists(tcPath))
             throw new Error(`Invalid ${tcPath} toolchain folder path`);
@@ -36,6 +41,7 @@ export class EngineLauncher {
         this.tcPath = tcPath;
         this.srpPath = srpPath;
         this.coreRootDir = tcPath;
+        this.engineExe = engineExe;
 
         // Read project settings to get data dir
         let srpSJSON = readFile(this.srpPath, 'utf8');
@@ -68,7 +74,7 @@ export class EngineLauncher {
     }
 
     public start (compile: boolean): Promise<EngineProcess> {
-        let engineExe = path.join(this.tcPath, 'engine', 'win64', 'dev', 'stingray_win64_dev.exe');
+        let engineExe = path.join(this.tcPath, 'engine', 'win64', 'dev', this.engineExe);
         let engineProcess = new EngineProcess(engineExe);
         let compilePromise = Promise.resolve();
         if (compile) {

--- a/src/stingray-debugger.ts
+++ b/src/stingray-debugger.ts
@@ -35,6 +35,8 @@ export interface AttachRequestArguments extends DebugProtocol.LaunchRequestArgum
 export interface LaunchRequestArguments extends DebugProtocol.LaunchRequestArguments {
     /** Stingray binary folder */
     toolchain: string;
+    /** Stingray executable name */
+    engine_exe: string;
     /** Project settings file path */
     project_file: string;
     /* Full paths of plugin folder to be scanned for additional plugins. (i.e. resource extensions). */
@@ -228,9 +230,11 @@ class StingrayDebugSession extends DebugSession {
     protected launchRequest(response: DebugProtocol.LaunchResponse, args: LaunchRequestArguments): void {
         let toolchainPath = args.toolchain;
         let projectFilePath = args.project_file;
+        let engineExe = args.engine_exe;
         // Launch engine
         let launcher = new EngineLauncher({
             tcPath: toolchainPath,
+            engineExe: engineExe,
             projectPath: projectFilePath,
             additionalPlugins: args.additional_plugins || [],
             commandLineArgs: args.command_line_args || []

--- a/tslint.json
+++ b/tslint.json
@@ -1,0 +1,114 @@
+//stingray/tools/command_line/ts-lint.rb
+{
+    "defaultSeverity": "error",
+    "extends": [
+        "tslint:recommended", // https://palantir.github.io/tslint/rules/
+        "tslint-eslint-rules" // https://www.npmjs.com/package/tslint-eslint-rules
+    ],
+    "jsRules": {},
+    "rules": {
+
+        // Bans specific types from being used. Does not ban the corresponding runtime objects from being used.
+        "ban-types": [true],
+
+        // Enforces the rule that interface names must or must not begin with a capital 'I'
+        "interface-name": [false],
+
+        // Disallows bitwise operators.
+        "no-bitwise": false,
+
+        // Checks variable names for various errors
+        "variable-name" : [true, "ban-keywords", "check-format", "allow-pascal-case", "allow-leading-underscore"],
+
+        // Enforces braces for if/for/do/while statements.
+        "curly": false,
+
+        // Requires === and !== in place of == and !=.
+        "triple-equals": true,
+
+        // Disallows object access via string literals
+        "no-string-literal": false,
+
+        // Enforces spacing whitespace
+        "whitespace": [false, "check-typecast"],
+
+        // Disallow irregular whitespace outside of strings and comments
+        "no-irregular-whitespace": true,
+
+        // Disallows unused expression statements.
+        "no-unused-expression": true,
+
+        // tslint-eslint-rules: disallow use of the new operator when not part of an assignment or comparison
+        "no-unused-new" : false,
+
+        // Forbids a ‘var’/’let’ statement or destructuring initializer to be initialized to ‘undefined’.
+        "no-unnecessary-initializer": true,
+
+        // Enforces a threshold of cyclomatic complexity.
+        "cyclomatic-complexity": [true, 42],
+
+        // Requires lines to be under a certain max length.
+        "max-line-length": [true, 240],
+
+        // Checks that type literal members are separated by semicolons. Enforces a trailing semicolon for multiline type literals.
+        "type-literal-delimiter": true,
+
+        // Requires or disallows trailing commas in array and object literals, destructuring assignments, function typings, named imports and exports and function parameters.
+        "trailing-comma" : [true],
+
+        // Requires keys in object literals to be sorted alphabetically.
+        "object-literal-sort-keys": false,
+
+        // Enforces use of ES6 object literal shorthand when possible.
+        "object-literal-shorthand": false,
+
+        // Disallows traditional (non-arrow) function expressions.
+        "only-arrow-functions": [false, "allow-named-functions"],
+
+        // Requires parentheses around the parameters of arrow function definitions.
+        "arrow-parens": [false],
+
+        // Requires explicit visibility declarations for class members.
+        "member-access": [false],
+
+        // Recommends a ‘for-of’ loop over a standard ‘for’ loop if the index is only used to access the array being iterated.
+        "prefer-for-of": false,
+
+        // Bans the use of specified console methods.
+        "no-console": [false],
+
+        // A file may not contain more than the specified number of classes
+        "max-classes-per-file": [false],
+
+        // tslint-eslint-rules: require space before/after arrow function's arrow
+        "ter-arrow-spacing": true,
+
+        // Disallows empty blocks. Blocks with a comment inside are not considered empty.
+        "no-empty": false,
+
+        // Disallows shadowing variable declarations
+        "no-shadowed-variable": false,
+
+        // Requires the use of `as Type` for type assertions instead of `<Type>`
+        "no-angle-bracket-type-assertion": false,
+
+        // Requires that variable declarations use const instead of let and var if possible.
+        "prefer-const": [true],
+
+        // Require or disallow a space before function parenthesis
+        "space-before-function-paren": [false, "always"],
+
+        // Enforce or not member ordering inside a class.
+        "member-ordering": [false],
+
+        // Disallows any type of assignment in any conditionals; this applies to do-while, for, if, and while statements
+        "no-conditional-assignment": false,
+
+        // Disallows multiple variable definitions in the same declaration statement
+        "one-variable-per-declaration": [false],
+
+        // Disallows use of internal `module`s and `namespace`s.
+        "no-namespace": false
+    },
+    "rulesDirectory": []
+}


### PR DESCRIPTION
Add the launch engine_exe config in order to specify what is the engine executable name to be launched.

i.e.:
```json
        {
            "type": "stingray",
            "request": "launch",
            "debugServer": 4711,
            "name": "testbed",
            "toolchain": "G:/stingray/build/binaries",
            "engine_exe": "interactive_win64_dev.exe",
            "project_file": "${workspaceRoot}/stingray-testbed.stingray_project",
            "compile": true,
            "additional_plugins": []
        }
```

-----
@lochrist please review